### PR TITLE
Update slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ TODO list.
 
 #### :speech_balloon: Stytch community Slack
 
-Join the discussion, ask questions, and suggest new features in our [Slack community](https://stytch.slack.com/join/shared_invite/zt-2f0fi1ruu-ub~HGouWRmPARM1MTwPESA)!
+Join the discussion, ask questions, and suggest new features in our [Slack community](https://stytch.com/docs/resources/support/overview)!
 
 #### :question: Need support?
 


### PR DESCRIPTION
Update Slack Invite links to point to the Support landing page as a single source of truth (Slack invite links expire after 400 uses and need to be updated semi frequently).